### PR TITLE
Update styling to incorporate Card Detail overflow scroll and breakpoints for Card layout

### DIFF
--- a/recipes/src/components/Card.jsx
+++ b/recipes/src/components/Card.jsx
@@ -54,7 +54,7 @@ function Card({ recipe }) {
 
   return (
     <>
-      <div className="flex flex-col border-solid overflow-hidden shadow-lg m-6 w-48 md:w-72 lg:w-104 h-fit bg-Pewter">
+      <div className="flex flex-col border-solid overflow-hidden shadow-lg m-6 w-2/3 md:w-1/4 h-fit bg-Pewter">
         <a
           className="hover:bg-Freesia transition-all duration-500 cursor-pointer"
           onClick={() => {

--- a/recipes/src/components/CardDetails.jsx
+++ b/recipes/src/components/CardDetails.jsx
@@ -14,17 +14,17 @@ function CardDetails({ recipe, nutrition, setToggleCardDetails }) {
   }
 
   return (
-    <div className="absolute top-10 left-1/6 w-4/5 h-auto outline-none">
+    <div className="absolute top-10 left-1/6 w-4/5 overflow-y-auto max-h-full border">
       <div className="bg-Gunmetal-gray">
         <div className="flex text-white border flex-col-reverse lg:flex-row ">
-          <div className="flex flex-col justify-center md:w-full lg:w-1/2">
+          <div className="flex flex-col justify-center items-center md:w-full lg:w-1/2">
             <img
               className="text-black object-cover w-full h-40 sm:h-48 md:h-64 lg:h-full"
               src={recipe.thumbnail_url}
               alt={"dish" + recipe.id}
             />
           </div>
-          <div className="flex flex-col px-10 py-20 justify-center w-full lg:w-1/2">
+          <div className="flex flex-col px-10 py-10 justify-center w-full lg:w-1/2">
             <div className="flex w-full justify-between">
               <h5 className="text-xs sm:text-xl font-bold">{recipe.name}</h5>
               <div>
@@ -66,26 +66,28 @@ function CardDetails({ recipe, nutrition, setToggleCardDetails }) {
             </div>
           </div>
         </div>
-        <table className="border-separate p-5 border-spacing-x-3 border-spacing-y-5 bg-Beige border-t-2">
-          <tbody>
-            <tr className="flex flex-col lg:flex-row m-3">
-              <td>
-                <h6 className="font-medium text-xs sm:text-xl mb-3">
-                  Instructions
-                </h6>
-              </td>
-              <td>
-                <ul className="px-12 text-xs list-disc list-outside space-y-2">
-                  {recipe.instructions.map((step, idx) => (
-                    <li key={idx}>{step.display_text}</li>
-                  ))}
-                </ul>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <div className="flex justify-center w-full px-10 pb-12 bg-Pewter items-center border-t-2 flex-col lg:flex-row">
-          <div className="flex flex-col w-full  pb-10 lg:max-w-xl lg:w-1/2 items-center justify-center">
+        <div className="bg-Beige border">
+          <table className="border-separate px-5 py-3 border-spacing-x-3 border-spacing-y-5">
+            <tbody>
+              <tr className="flex flex-col lg:flex-row m-3">
+                <td>
+                  <h6 className="font-medium text-xs sm:text-xl mb-3">
+                    Instructions
+                  </h6>
+                </td>
+                <td>
+                  <ul className="px-12 text-xs list-disc list-outside space-y-2">
+                    {recipe.instructions.map((step, idx) => (
+                      <li key={idx}>{step.display_text}</li>
+                    ))}
+                  </ul>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div className="flex flex-col lg:flex-row w-full px-10 pb-3 bg-Pewter border">
+          <div className="flex flex-col w-full pb-10 lg:max-w-xl lg:w-1/2 items-center justify-center">
             <h6 className="font-medium text-xs sm:text-xl pt-8 pb-5">Video</h6>
             {recipe.video_url === null ? (
               <div className="px-5 text-xs sm:text-xl text-Gunmetal-gray">
@@ -102,8 +104,8 @@ function CardDetails({ recipe, nutrition, setToggleCardDetails }) {
               />
             )}
           </div>
-          <div className="flex flex-col w-full lg:w-1/2 h-full lg:pl-10 items-center pl-2 justify-center">
-            <h6 className="font-medium text-xs sm:text-xl pt-8 pb-5">
+          <div className="flex flex-col w-full pb-10 lg:max-w-xl lg:w-1/2 items-center pl-2 lg:pl-10">
+            <h6 className="font-medium text-xs sm:text-xl pt-8 pb-4">
               Nutrition Value
             </h6>
             {isEmpty(nutrition) ? (

--- a/recipes/src/components/CardList.jsx
+++ b/recipes/src/components/CardList.jsx
@@ -21,7 +21,7 @@ function CardList({ cardDetails }) {
   return (
     <div className="flex flex-col">
       <div
-        className="relative flex flex-wrap items-center justify-evenly mx-auto mb-5 py-6 bg-Gunmetal-gray w-screen max-w-screen-25"
+        className="relative flex flex-col md:flex-row flex-wrap items-center justify-evenly mx-auto mb-5 py-6 bg-Gunmetal-gray w-screen max-w-screen-25"
         id="card-holder"
       >
         {recipes.slice(0, loadMore).map(recipe => (


### PR DESCRIPTION
- Show 3 cards per row in CardList until hitting breakpoint for 1 card per row
- Add scroll for Card Detail to maintain manageable overall container size